### PR TITLE
MINOR Adjust line lengths to conform to PSR-2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/Firesphere/silverstripe-googlemapsfield.svg?style=svg)](https://circleci.com/gh/Firesphere/silverstripe-googlemapsfield)
+[![CircleCI](https://img.shields.io/circleci/project/github/Firesphere/silverstripe-googlemapsfield.svg)](https://circleci.com/gh/Firesphere/silverstripe-googlemapsfield)
 [![codecov](https://codecov.io/gh/Firesphere/silverstripe-googlemapsfield/branch/master/graph/badge.svg)](https://codecov.io/gh/Firesphere/silverstripe-googlemapsfield)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Firesphere/silverstripe-googlemapsfield/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Firesphere/silverstripe-googlemapsfield/?branch=master)
 

--- a/src/extensions/SiteConfigExtension.php
+++ b/src/extensions/SiteConfigExtension.php
@@ -25,8 +25,14 @@ class SiteConfigExtension extends DataExtension
         parent::updateCMSFields($fields);
 
         $fields->addFieldsToTab('Root.GoogleMaps', [
-            TextField::create('MapsBrowserKey', _t(static::class . 'BROWSERKEY', 'Google API Browser key for address search')),
-            TextField::create('MapsServerKey', _t(static::class . 'SERVERKEY', 'Google API Server key for geolocation')),
+            TextField::create(
+                'MapsBrowserKey',
+                _t(self::class . 'BROWSERKEY', 'Google API Browser key for address search')
+            ),
+            TextField::create(
+                'MapsServerKey',
+                _t(self::class . 'SERVERKEY', 'Google API Server key for geolocation')
+            ),
         ]);
     }
 }

--- a/src/forms/GoogleMapsField.php
+++ b/src/forms/GoogleMapsField.php
@@ -59,7 +59,9 @@ class GoogleMapsField extends TextField
     {
         $config = SiteConfig::current_site_config();
 
-        Requirements::javascript('https://maps.googleapis.com/maps/api/js?key=' . $config->MapsBrowserKey . '&libraries=places');
+        Requirements::javascript(
+            'https://maps.googleapis.com/maps/api/js?key=' . $config->MapsBrowserKey . '&libraries=places'
+        );
         Requirements::javascript('firesphere/googlemapsfield:client/dist/main.js');
 
         return parent::Field($properties);

--- a/tests/unit/GoogleMapsFieldTest.php
+++ b/tests/unit/GoogleMapsFieldTest.php
@@ -50,7 +50,17 @@ class GoogleMapsFieldTest extends SapphireTest
     {
         $field = GoogleMapsField::create('Test');
 
-        $fields = '<input type="hidden" name="GoogleMapsLatField" class="hidden" id="GoogleMapsLatField" /><input type="hidden" name="GoogleMapsLngField" class="hidden" id="GoogleMapsLngField" /><input type="hidden" name="subpremise" class="hidden" id="subpremise" /><input type="hidden" name="street_number" class="hidden" id="street_number" /><input type="hidden" name="route" class="hidden" id="route" /><input type="hidden" name="sublocality_level_1" class="hidden" id="sublocality_level_1" /><input type="hidden" name="locality" class="hidden" id="locality" /><input type="hidden" name="administrative_area_level_1" class="hidden" id="administrative_area_level_1" /><input type="hidden" name="country" class="hidden" id="country" /><input type="hidden" name="postal_code" class="hidden" id="postal_code" />';
+        $fields = '<input type="hidden" name="GoogleMapsLatField" class="hidden" id="GoogleMapsLatField" />'
+            . '<input type="hidden" name="GoogleMapsLngField" class="hidden" id="GoogleMapsLngField" />'
+            . '<input type="hidden" name="subpremise" class="hidden" id="subpremise" />'
+            . '<input type="hidden" name="street_number" class="hidden" id="street_number" />'
+            . '<input type="hidden" name="route" class="hidden" id="route" />'
+            . '<input type="hidden" name="sublocality_level_1" class="hidden" id="sublocality_level_1" />'
+            . '<input type="hidden" name="locality" class="hidden" id="locality" />'
+            . '<input type="hidden" name="administrative_area_level_1" class="hidden"'
+            . ' id="administrative_area_level_1" />'
+            . '<input type="hidden" name="country" class="hidden" id="country" />'
+            . '<input type="hidden" name="postal_code" class="hidden" id="postal_code" />';
 
         $this->assertEquals($fields, $field->getHiddenFields());
     }


### PR DESCRIPTION
Also switches `static::class` to `self::class` in localisation calls, since `static::class` is not supported by the text collector yet (but `self::class` is)